### PR TITLE
Add install instructions for Arch users

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Composite Blur Plugin is a comprehensive blur plugin that provides blur algorith
 
 Go to the [Releases Page](https://github.com/FiniteSingularity/obs-composite-blur/releases), click `Assets` under the latest release, and select either the Windows, MacOS, or Linux installer. Download the file, and run it, to install for your copy of OBS.
 
+### From AUR
+
+Arch Linux users can install obs-composite-blur from the [AUR](https://aur.archlinux.org/) using an [AUR helper](https://wiki.archlinux.org/title/AUR_helpers). For example:
+
+```sh
+paru -S obs-composite-blur
+```
+
 ## Blur Algorithms
 
 Composite Blur provides several different algorithms to blur your sources. The blur algorithms are written with performance in mind using techniques like linear sampling and GPU texture interpolation to stretch what your GPU can do. Additonally, the algorithms have been written with finely adjustable blur amounts, that allow for smooth transitions and animations when using other plugins like Move Transition.


### PR DESCRIPTION
I created a [package](https://aur.archlinux.org/packages/obs-composite-blur) for Arch Linux users for an easier installation. This PR adds a simple note, so users can find it from the README.

While creating the [packaging script](https://github.com/dnaka91/pkgbuilds/blob/master/obs-composite-blur/PKGBUILD), I noticed a few _odd_ behaviors in the **CMakeLists.txt**. It creates several files where they shouldn't be, so I had to manually relocate them. Hopefully the config can be adjusted in the future, so they end up in the right place.

This is the way it currently looks like after building and installing the project:

```txt
usr
├── data
│  └── obs-plugins
│     └── obs-composite-blur
│        ├── locale
│        │  └── en-US.ini
│        └── shaders
│           ├── box_1d.effect
│           ├── box_radial.effect
│           ├── box_tiltshift.effect
│           ├── composite.effect
│           ├── dual_kawase_down_sample.effect
│           ├── dual_kawase_up_sample.effect
│           ├── effect_mask_circle.effect
│           ├── effect_mask_crop.effect
│           ├── effect_mask_source.effect
│           ├── gaussian_1d.effect
│           ├── gaussian_1d_texture.effect
│           ├── gaussian_motion.effect
│           ├── gaussian_motion_texture.effect
│           ├── gaussian_radial.effect
│           ├── gaussian_radial_texture.effect
│           ├── mix.effect
│           ├── pixelate_circle.effect
│           ├── pixelate_hexagonal.effect
│           ├── pixelate_square.effect
│           └── pixelate_triangle.effect
├── lib
│  └── obs-plugins
│     └── obs-composite-blur.so
├── obs-plugins
│  └── 64bit
│     └── obs-composite-blur.so
└── share
   └── obs
      └── obs-plugins
         └── obs-composite-blur
            └── locale
               └── en-US.ini
```

And this is the way it should look like:

```txt
usr
├── lib
│  └── obs-plugins
│     └── obs-composite-blur.so
└── share
   └── obs
      └── obs-plugins
         └── obs-composite-blur
            ├── locale
            │  └── en-US.ini
            └── shaders
               ├── box_1d.effect
               ├── box_radial.effect
               ├── box_tiltshift.effect
               ├── composite.effect
               ├── dual_kawase_down_sample.effect
               ├── dual_kawase_up_sample.effect
               ├── effect_mask_circle.effect
               ├── effect_mask_crop.effect
               ├── effect_mask_source.effect
               ├── gaussian_1d.effect
               ├── gaussian_1d_texture.effect
               ├── gaussian_motion.effect
               ├── gaussian_motion_texture.effect
               ├── gaussian_radial.effect
               ├── gaussian_radial_texture.effect
               ├── mix.effect
               ├── pixelate_circle.effect
               ├── pixelate_hexagonal.effect
               ├── pixelate_square.effect
               └── pixelate_triangle.effect
```

The correct locations are:
- `/usr/lib/obs-plugins/obs-composite-blur.so`
- `/usr/share/obs/obs-plugins/obs-composite-blur/locale/en-US.ini`

The _odd_ files are:
- `/usr/obs-plugins/64bit/obs-composite-blur.so`:
  - It's a duplicate of the shared library under `/usr/lib/obs-plugins`
  - The `/usr/obs-plugins` prefix is not correct
- `/usr/data/obs-plugins/...`:
  - These should be under `/usr/share/obs/obs-plugins`, together with the locales
  - The locales seem to be duplicates of what is already in the correct location.

I can confirm that the plugin works correct after relocating the mentioned files, but I DID NOT try using the plugin **before** applying the relocation steps.

It's interesting that the shaders are put in `/usr/data`, despite not being mentioned in the CMakeLists.txt. Probably it's auto-selected by the OBS CMake helper scripts? Not an expert on that topic. Maybe there are some extra settings to push it in the right direction.
