### PR TITLE
Changes Direct3D/OpenGL detection from compile-time to runtime.

### DIFF
--- a/src/blur/gaussian.c
+++ b/src/blur/gaussian.c
@@ -86,21 +86,25 @@ static void gaussian_area_blur(composite_blur_filter_data_t *data)
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, texture);
 
-#ifdef _WIN32
-	if (data->param_weight) {
-		gs_effect_set_val(data->param_weight, data->kernel.array,
-				  data->kernel.num * sizeof(float));
+	switch (data->device_type) {
+	case GS_DEVICE_DIRECT3D_11:
+		if (data->param_weight) {
+			gs_effect_set_val(data->param_weight,
+					  data->kernel.array,
+					  data->kernel.num * sizeof(float));
+		}
+		if (data->param_offset) {
+			gs_effect_set_val(data->param_offset,
+					  data->offset.array,
+					  data->offset.num * sizeof(float));
+		}
+		break;
+	case GS_DEVICE_OPENGL:
+		if (data->param_kernel_texture) {
+			gs_effect_set_texture(data->param_kernel_texture,
+					      data->kernel_texture);
+		}
 	}
-	if (data->param_offset) {
-		gs_effect_set_val(data->param_offset, data->offset.array,
-				  data->offset.num * sizeof(float));
-	}
-#else
-	if (data->param_kernel_texture) {
-		gs_effect_set_texture(data->param_kernel_texture,
-				      data->kernel_texture);
-	}
-#endif
 
 	const int k_size = (int)data->kernel_size;
 	if (data->param_kernel_size) {
@@ -131,12 +135,10 @@ static void gaussian_area_blur(composite_blur_filter_data_t *data)
 	image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, texture);
 
-#ifndef _WIN32
-	if (data->param_kernel_texture) {
+	if (data->device_type == GS_DEVICE_OPENGL && data->param_kernel_texture) {
 		gs_effect_set_texture(data->param_kernel_texture,
 				      data->kernel_texture);
 	}
-#endif
 
 	texel_step.x = 0.0f;
 	texel_step.y = 1.0f / data->height;
@@ -177,21 +179,26 @@ static void gaussian_directional_blur(composite_blur_filter_data_t *data)
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, texture);
 
-#ifdef _WIN32
-	if (data->param_weight) {
-		gs_effect_set_val(data->param_weight, data->kernel.array,
-				  data->kernel.num * sizeof(float));
+	switch (data->device_type) {
+	case GS_DEVICE_DIRECT3D_11:
+		if (data->param_weight) {
+			gs_effect_set_val(data->param_weight,
+					  data->kernel.array,
+					  data->kernel.num * sizeof(float));
+		}
+		if (data->param_offset) {
+			gs_effect_set_val(data->param_offset,
+					  data->offset.array,
+					  data->offset.num * sizeof(float));
+		}
+		break;
+	case GS_DEVICE_OPENGL:
+		if (data->param_kernel_texture) {
+			gs_effect_set_texture(data->param_kernel_texture,
+					      data->kernel_texture);
+		}
+		break;
 	}
-	if (data->param_offset) {
-		gs_effect_set_val(data->param_offset, data->offset.array,
-				  data->offset.num * sizeof(float));
-	}
-#else
-	if (data->param_kernel_texture) {
-		gs_effect_set_texture(data->param_kernel_texture,
-				      data->kernel_texture);
-	}
-#endif
 
 	const int k_size = (int)data->kernel_size;
 	if (data->param_kernel_size) {
@@ -241,21 +248,26 @@ static void gaussian_motion_blur(composite_blur_filter_data_t *data)
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, texture);
 
-#ifdef _WIN32
-	if (data->param_weight) {
-		gs_effect_set_val(data->param_weight, data->kernel.array,
-				  data->kernel.num * sizeof(float));
+	switch (data->device_type) {
+	case GS_DEVICE_DIRECT3D_11:
+		if (data->param_weight) {
+			gs_effect_set_val(data->param_weight,
+					  data->kernel.array,
+					  data->kernel.num * sizeof(float));
+		}
+		if (data->param_offset) {
+			gs_effect_set_val(data->param_offset,
+					  data->offset.array,
+					  data->offset.num * sizeof(float));
+		}
+		break;
+	case GS_DEVICE_OPENGL:
+		if (data->param_kernel_texture) {
+			gs_effect_set_texture(data->param_kernel_texture,
+					      data->kernel_texture);
+		}
+		break;
 	}
-	if (data->param_offset) {
-		gs_effect_set_val(data->param_offset, data->offset.array,
-				  data->offset.num * sizeof(float));
-	}
-#else
-	if (data->param_kernel_texture) {
-		gs_effect_set_texture(data->param_kernel_texture,
-				      data->kernel_texture);
-	}
-#endif
 
 	const int k_size = (int)data->kernel_size;
 	if (data->param_kernel_size) {
@@ -306,21 +318,26 @@ static void gaussian_zoom_blur(composite_blur_filter_data_t *data)
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, texture);
 
-#ifdef _WIN32
-	if (data->param_weight) {
-		gs_effect_set_val(data->param_weight, data->kernel.array,
-				  data->kernel.num * sizeof(float));
+	switch (data->device_type) {
+	case GS_DEVICE_DIRECT3D_11:
+		if (data->param_weight) {
+			gs_effect_set_val(data->param_weight,
+					  data->kernel.array,
+					  data->kernel.num * sizeof(float));
+		}
+		if (data->param_offset) {
+			gs_effect_set_val(data->param_offset,
+					  data->offset.array,
+					  data->offset.num * sizeof(float));
+		}
+		break;
+	case GS_DEVICE_OPENGL:
+		if (data->param_kernel_texture) {
+			gs_effect_set_texture(data->param_kernel_texture,
+					      data->kernel_texture);
+		}
+		break;
 	}
-	if (data->param_offset) {
-		gs_effect_set_val(data->param_offset, data->offset.array,
-				  data->offset.num * sizeof(float));
-	}
-#else
-	if (data->param_kernel_texture) {
-		gs_effect_set_texture(data->param_kernel_texture,
-				      data->kernel_texture);
-	}
-#endif
 
 	const int k_size = (int)data->kernel_size;
 	if (data->param_kernel_size) {
@@ -360,11 +377,12 @@ static void gaussian_zoom_blur(composite_blur_filter_data_t *data)
 
 static void load_1d_gaussian_effect(composite_blur_filter_data_t *filter)
 {
-#ifdef _WIN32
-	const char *effect_file_path = "/shaders/gaussian_1d.effect";
-#else
-	const char *effect_file_path = "/shaders/gaussian_1d_texture.effect";
-#endif
+
+	const char *effect_file_path =
+		filter->device_type == GS_DEVICE_DIRECT3D_11
+			? "/shaders/gaussian_1d.effect"
+			: "/shaders/gaussian_1d_texture.effect";
+
 	filter->effect = load_shader_effect(filter->effect, effect_file_path);
 	if (filter->effect) {
 		size_t effect_count = gs_effect_get_num_params(filter->effect);
@@ -393,12 +411,11 @@ static void load_1d_gaussian_effect(composite_blur_filter_data_t *filter)
 
 static void load_motion_gaussian_effect(composite_blur_filter_data_t *filter)
 {
-#ifdef _WIN32
-	const char *effect_file_path = "/shaders/gaussian_motion.effect";
-#else
+
 	const char *effect_file_path =
-		"/shaders/gaussian_motion_texture.effect";
-#endif
+		filter->device_type == GS_DEVICE_DIRECT3D_11
+			? "/shaders/gaussian_motion.effect"
+			: "/shaders/gaussian_motion_texture.effect";
 	filter->effect = load_shader_effect(filter->effect, effect_file_path);
 	if (filter->effect) {
 		size_t effect_count = gs_effect_get_num_params(filter->effect);
@@ -427,12 +444,10 @@ static void load_motion_gaussian_effect(composite_blur_filter_data_t *filter)
 
 static void load_radial_gaussian_effect(composite_blur_filter_data_t *filter)
 {
-#ifdef _WIN32
-	const char *effect_file_path = "/shaders/gaussian_radial.effect";
-#else
 	const char *effect_file_path =
-		"/shaders/gaussian_radial_texture.effect";
-#endif
+		filter->device_type == GS_DEVICE_DIRECT3D_11
+			? "/shaders/gaussian_radial.effect"
+			: "/shaders/gaussian_radial_texture.effect";
 	filter->effect = load_shader_effect(filter->effect, effect_file_path);
 	if (filter->effect) {
 		size_t effect_count = gs_effect_get_num_params(filter->effect);

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -135,6 +135,12 @@ static void *composite_blur_create(obs_data_t *settings, obs_source_t *source)
 	da_init(filter->kernel);
 	//composite_blur_defaults(settings);
 	obs_source_update(source, settings);
+	obs_enter_graphics();
+	// Grab the device type, can be:
+	// GS_DEVICE_OPENGL
+	// GS_DEVICE_DIRECT3D_11
+	filter->device_type = gs_get_device_type();
+	obs_leave_graphics();
 	return filter;
 }
 

--- a/src/obs-composite-blur-filter.h
+++ b/src/obs-composite-blur-filter.h
@@ -213,6 +213,8 @@ struct composite_blur_filter_data {
 	uint32_t width;
 	uint32_t height;
 
+	uint32_t device_type;
+
 	// Callback Functions
 	void (*video_render)(composite_blur_filter_data_t *filter);
 	void (*load_effect)(composite_blur_filter_data_t *filter);


### PR DESCRIPTION
Previously, there was a platform detection macro that was used at compile time to switch included code for gaussian blur from an array-based kernel input for Direct3D to a texture-based kernel input for OpenGL.  The assumption was that Mac/Linux users use OpenGL, and Windows users use Direct3D.  This assumption was not always correct, as OBS on Windows can be launched with a `--allow-opengl` flag to allow the user to switch away from Direct3D to OpenGL.  This PR switches to a runtime check to see what render engine is actually being used, and should fix #47 .