### PR TITLE
Fixes both issues in #54.

### DIFF
--- a/src/blur/box.c
+++ b/src/blur/box.c
@@ -72,6 +72,13 @@ static void box_area_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_BOX_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 	const int passes = data->passes < 1 ? 1 : data->passes;
 	for (int i = 0; i < passes; i++) {
@@ -148,6 +155,13 @@ static void box_directional_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_BOX_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 
 	for (int i = 0; i < data->passes; i++) {
@@ -202,6 +216,13 @@ static void box_zoom_blur(composite_blur_filter_data_t *data)
 	gs_texture_t *texture = gs_texrender_get_texture(data->input_texrender);
 
 	if (!effect || !texture) {
+		return;
+	}
+
+	if (data->radius < MIN_BOX_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
 		return;
 	}
 
@@ -264,6 +285,13 @@ static void box_tilt_shift_blur(composite_blur_filter_data_t *data)
 	gs_texture_t *texture = gs_texrender_get_texture(data->input_texrender);
 
 	if (!effect || !texture) {
+		return;
+	}
+
+	if (data->radius < MIN_BOX_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
 		return;
 	}
 

--- a/src/blur/box.h
+++ b/src/blur/box.h
@@ -5,6 +5,8 @@
 #include "../obs-utils.h"
 #include "../obs-composite-blur-filter.h"
 
+#define MIN_BOX_BLUR_RADIUS 0.01f
+
 extern void set_box_blur_types(obs_properties_t *props);
 extern void box_setup_callbacks(composite_blur_filter_data_t *data);
 extern void render_video_box(composite_blur_filter_data_t *data);

--- a/src/blur/dual_kawase.c
+++ b/src/blur/dual_kawase.c
@@ -131,10 +131,9 @@ static void dual_kawase_blur(composite_blur_filter_data_t *data)
 {
 	gs_texture_t *texture = gs_texrender_get_texture(data->input_texrender);
 	if (data->kawase_passes <= 1) {
-		// TODO- COPY INPUT TO OUTPUT TO PRESERVE INPUT.
-		gs_texrender_t *tmp = data->input_texrender;
-		data->input_texrender = data->output_texrender;
-		data->output_texrender = tmp;
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
 		return;
 	}
 	gs_effect_t *effect_up = data->effect;

--- a/src/blur/gaussian.c
+++ b/src/blur/gaussian.c
@@ -78,6 +78,13 @@ static void gaussian_area_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_GAUSSIAN_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 
 	data->render2 = create_or_reset_texrender(data->render2);
@@ -173,6 +180,13 @@ static void gaussian_directional_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_GAUSSIAN_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 
 	// 1. Single pass- blur only in one direction
@@ -239,6 +253,13 @@ static void gaussian_motion_blur(composite_blur_filter_data_t *data)
 	gs_texture_t *texture = gs_texrender_get_texture(data->input_texrender);
 
 	if (!effect || !texture) {
+		return;
+	}
+
+	if (data->radius < MIN_GAUSSIAN_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
 		return;
 	}
 
@@ -312,6 +333,13 @@ static void gaussian_zoom_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_GAUSSIAN_BLUR_RADIUS) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 
 	// 1. Single pass- blur only in one direction
@@ -377,7 +405,6 @@ static void gaussian_zoom_blur(composite_blur_filter_data_t *data)
 
 static void load_1d_gaussian_effect(composite_blur_filter_data_t *filter)
 {
-
 	const char *effect_file_path =
 		filter->device_type == GS_DEVICE_DIRECT3D_11
 			? "/shaders/gaussian_1d.effect"

--- a/src/blur/gaussian.h
+++ b/src/blur/gaussian.h
@@ -6,6 +6,8 @@
 #include "../obs-composite-blur-filter.h"
 #include "gaussian-kernel.h"
 
+#define MIN_GAUSSIAN_BLUR_RADIUS 0.01f
+
 extern void set_gaussian_blur_types(obs_properties_t *props);
 extern void gaussian_setup_callbacks(composite_blur_filter_data_t *data);
 extern void render_video_gaussian(composite_blur_filter_data_t *data);

--- a/src/blur/pixelate.c
+++ b/src/blur/pixelate.c
@@ -47,6 +47,13 @@ static void pixelate_square_blur(composite_blur_filter_data_t *data)
 		return;
 	}
 
+	if (data->radius < MIN_PIXELATE_BLUR_SIZE) {
+		data->output_texrender =
+			create_or_reset_texrender(data->output_texrender);
+		texrender_set_texture(texture, data->output_texrender);
+		return;
+	}
+
 	texture = blend_composite(texture, data);
 
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");

--- a/src/blur/pixelate.h
+++ b/src/blur/pixelate.h
@@ -5,6 +5,8 @@
 #include "../obs-utils.h"
 #include "../obs-composite-blur-filter.h"
 
+#define MIN_PIXELATE_BLUR_SIZE 1.01f
+
 extern void set_pixelate_blur_types(obs_properties_t *props);
 extern void pixelate_setup_callbacks(composite_blur_filter_data_t *data);
 extern void render_video_pixelate(composite_blur_filter_data_t *data);

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -506,8 +506,8 @@ static void apply_effect_mask_source(composite_blur_filter_data_t *filter)
 
 		// Set up a tex renderer for source
 		source_render = gs_texrender_create(format, GS_ZS_NONE);
-		uint32_t base_width = obs_source_get_base_width(source);
-		uint32_t base_height = obs_source_get_base_height(source);
+		uint32_t base_width = obs_source_get_width(source);
+		uint32_t base_height = obs_source_get_height(source);
 		gs_blend_state_push();
 		gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
 		if (gs_texrender_begin_with_color_space(
@@ -925,7 +925,7 @@ static obs_properties_t *composite_blur_properties(void *data)
 
 	obs_properties_add_int_slider(
 		props, "kawase_passes",
-		obs_module_text("CompositeBlurFilter.DualKawase.Passes"), 1,
+		obs_module_text("CompositeBlurFilter.DualKawase.Passes"), 0,
 		1025, 1);
 
 	obs_properties_add_float_slider(

--- a/src/obs-utils.c
+++ b/src/obs-utils.c
@@ -45,6 +45,24 @@ bool add_source_to_list(void *data, obs_source_t *source)
 	return true;
 }
 
+void texrender_set_texture(gs_texture_t *source, gs_texrender_t *dest)
+{
+	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
+	uint32_t w = gs_texture_get_width(source);
+	uint32_t h = gs_texture_get_height(source);
+
+	gs_eparam_t *image = gs_effect_get_param_by_name(pass_through, "image");
+	gs_effect_set_texture(image, source);
+
+	if (gs_texrender_begin(dest, w, h)) {
+		gs_ortho(0.0f, (float)w, 0.0f, (float)h, -100.0f, 100.0f);
+		while (gs_effect_loop(pass_through, "Draw"))
+			gs_draw_sprite(source, 0, w, h);
+		gs_texrender_end(dest);
+	}
+}
+
 // Loads the shader file at `effect_file_path` into *effect
 gs_effect_t *load_shader_effect(gs_effect_t *effect,
 				const char *effect_file_path)

--- a/src/obs-utils.h
+++ b/src/obs-utils.h
@@ -11,6 +11,7 @@
 extern gs_texrender_t *create_or_reset_texrender(gs_texrender_t *render);
 extern void set_blending_parameters();
 extern void set_render_parameters();
+void texrender_set_texture(gs_texture_t *source, gs_texrender_t *dest);
 extern bool add_source_to_list(void *data, obs_source_t *source);
 gs_effect_t *load_shader_effect(gs_effect_t *effect,
 				const char *effect_file_path);


### PR DESCRIPTION
This PR fixes both the improper scaling of filter-scaled sources (e.g.- sources using the scale/aspect ratio filter), and the improper rendering of masked Kawase blur filtered sources at 1 or lower blur, reported in issue #54 .

In addition, all blur types now have an early exit that passes through the original source texture if no blur is needed, so zero blur will be zero blur, fixing #17.