### PR TITLE
Fixes bug where zero blur was causing sources with alpha not to redraw properly.

### DIFF
--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -396,10 +396,8 @@ static void get_input_source(composite_blur_filter_data_t *filter)
 			       filter->height)) {
 
 		set_blending_parameters();
-
 		gs_ortho(0.0f, (float)filter->width, 0.0f,
 			 (float)filter->height, -100.0f, 100.0f);
-
 		obs_source_process_filter_end(filter->context, pass_through,
 					      filter->width, filter->height);
 		gs_texrender_end(filter->input_texrender);

--- a/src/obs-utils.c
+++ b/src/obs-utils.c
@@ -54,13 +54,14 @@ void texrender_set_texture(gs_texture_t *source, gs_texrender_t *dest)
 
 	gs_eparam_t *image = gs_effect_get_param_by_name(pass_through, "image");
 	gs_effect_set_texture(image, source);
-
+	set_blending_parameters();
 	if (gs_texrender_begin(dest, w, h)) {
 		gs_ortho(0.0f, (float)w, 0.0f, (float)h, -100.0f, 100.0f);
 		while (gs_effect_loop(pass_through, "Draw"))
 			gs_draw_sprite(source, 0, w, h);
 		gs_texrender_end(dest);
 	}
+	gs_blend_state_pop();
 }
 
 // Loads the shader file at `effect_file_path` into *effect


### PR DESCRIPTION
A missing `gs_blend_state_pop()` in the input source passthrough was causing sources with alpha channels to not redraw properly, causing a trailing artifact.  Fixes #76 .