### PR TITLE
Bugfix/memory leaks

### DIFF
--- a/src/blur/gaussian.c
+++ b/src/blur/gaussian.c
@@ -644,4 +644,7 @@ static void sample_kernel(float radius, composite_blur_filter_data_t *filter)
 		blog(LOG_WARNING, "Gaussian Texture couldn't be created.");
 	}
 	obs_leave_graphics();
+	da_free(d_weights);
+	da_free(d_offsets);
+	da_free(weight_offset_texture);
 }

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -180,14 +180,19 @@ static void composite_blur_destroy(void *data)
 	if (filter->output_texrender) {
 		gs_texrender_destroy(filter->output_texrender);
 	}
+	if (filter->composite_render) {
+		gs_texrender_destroy(filter->composite_render);
+	}
 
 	if (filter->kernel_texture) {
 		gs_texture_destroy(filter->kernel_texture);
 	}
-
 	if (filter->mask_image) {
 		gs_image_file_free(filter->mask_image);
 	}
+
+	da_free(filter->offset);
+	da_free(filter->kernel);
 
 	obs_leave_graphics();
 	bfree(filter);
@@ -1529,6 +1534,7 @@ static void load_composite_effect(composite_blur_filter_data_t *filter)
 	dstr_cat(&filename, obs_get_module_data_path(obs_current_module()));
 	dstr_cat(&filename, "/shaders/composite.effect");
 	shader_text = load_shader_from_file(filename.array);
+	dstr_free(&filename);
 	char *errors = NULL;
 
 	obs_enter_graphics();
@@ -1573,6 +1579,7 @@ static void load_crop_mask_effect(composite_blur_filter_data_t *filter)
 	dstr_cat(&filename, "/shaders/effect_mask_crop.effect");
 	shader_text = load_shader_from_file(filename.array);
 	char *errors = NULL;
+	dstr_free(&filename);
 
 	obs_enter_graphics();
 	filter->effect_mask_effect =
@@ -1630,6 +1637,7 @@ static void load_source_mask_effect(composite_blur_filter_data_t *filter)
 	dstr_cat(&filename, "/shaders/effect_mask_source.effect");
 	shader_text = load_shader_from_file(filename.array);
 	char *errors = NULL;
+	dstr_free(&filename);
 
 	obs_enter_graphics();
 	filter->effect_mask_effect =
@@ -1682,6 +1690,7 @@ static void load_circle_mask_effect(composite_blur_filter_data_t *filter)
 	dstr_cat(&filename, "/shaders/effect_mask_circle.effect");
 	shader_text = load_shader_from_file(filename.array);
 	char *errors = NULL;
+	dstr_free(&filename);
 
 	obs_enter_graphics();
 	filter->effect_mask_effect =
@@ -1736,6 +1745,7 @@ static void load_mix_effect(composite_blur_filter_data_t *filter)
 	dstr_cat(&filename, "/shaders/mix.effect");
 	shader_text = load_shader_from_file(filename.array);
 	char *errors = NULL;
+	dstr_free(&filename);
 
 	obs_enter_graphics();
 	filter->mix_effect = gs_effect_create(shader_text, NULL, &errors);

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -149,7 +149,7 @@ static void *composite_blur_create(obs_data_t *settings, obs_source_t *source)
 
 static void composite_blur_destroy(void *data)
 {
-	struct composite_blur_filter_data *filter = data;
+	composite_blur_filter_data_t *filter = data;
 
 	obs_enter_graphics();
 	if (filter->effect) {
@@ -189,6 +189,14 @@ static void composite_blur_destroy(void *data)
 	}
 	if (filter->mask_image) {
 		gs_image_file_free(filter->mask_image);
+	}
+
+	if (filter->background) {
+		obs_weak_source_release(filter->background);
+	}
+
+	if (filter->mask_source_source) {
+		obs_weak_source_release(filter->mask_source_source);
 	}
 
 	da_free(filter->offset);
@@ -1772,7 +1780,7 @@ static void load_mix_effect(composite_blur_filter_data_t *filter)
 }
 
 gs_texture_t *blend_composite(gs_texture_t *texture,
-			      struct composite_blur_filter_data *data)
+			      composite_blur_filter_data_t *data)
 {
 	// Get source
 	obs_source_t *source =

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -189,6 +189,7 @@ static void composite_blur_destroy(void *data)
 	}
 	if (filter->mask_image) {
 		gs_image_file_free(filter->mask_image);
+		bfree(filter->mask_image);
 	}
 
 	if (filter->background) {
@@ -869,7 +870,7 @@ static void apply_effect_mask_circle(composite_blur_filter_data_t *filter)
 
 static obs_properties_t *composite_blur_properties(void *data)
 {
-	struct composite_blur_filter_data *filter = data;
+	composite_blur_filter_data_t *filter = data;
 
 	obs_properties_t *props = obs_properties_create();
 	obs_properties_set_param(props, filter, NULL);

--- a/src/obs-utils.c
+++ b/src/obs-utils.c
@@ -108,10 +108,9 @@ gs_effect_t *load_shader_effect(gs_effect_t *effect,
 // Performs loading of shader from file.  Properly includes #include directives.
 char *load_shader_from_file(const char *file_name)
 {
-	char *file_ptr = os_quick_read_utf8_file(file_name);
-	if (file_ptr == NULL)
+	char *file = os_quick_read_utf8_file(file_name);
+	if (file == NULL)
 		return NULL;
-	char *file = bstrdup(os_quick_read_utf8_file(file_name));
 	char **lines = strlist_split(file, '\n', true);
 	struct dstr shader_file;
 	dstr_init(&shader_file);
@@ -148,5 +147,6 @@ char *load_shader_from_file(const char *file_name)
 
 	bfree(file);
 	strlist_free(lines);
+
 	return shader_file.array;
 }


### PR DESCRIPTION
Fixes several small memory leaks, where some dynamic strings, arrays, and an image file were not being freed when a filter was being destroyed.

Thanks to @YorVeX for reporting the issue, and to @exeldro for helping with the fix.