### PR TITLE
Attempt to fix the color consistency issue

### DIFF
--- a/data/shaders/render_output.effect
+++ b/data/shaders/render_output.effect
@@ -1,0 +1,37 @@
+uniform float4x4 ViewProj;
+uniform texture2d image;
+uniform texture2d output_image;
+
+sampler_state textureSampler{
+    Filter = Linear;
+    AddressU = Clamp;
+    AddressV = Clamp;
+    MinLOD = 0;
+    MaxLOD = 0;
+};
+
+struct VertData
+{
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+VertData mainTransform(VertData v_in)
+{
+	v_in.pos = mul(float4(v_in.pos.xyz, 1.0), ViewProj);
+	return v_in;
+}
+
+float4 mainImage(VertData v_in) : TARGET
+{
+	return output_image.Sample(textureSampler, v_in.uv);
+}
+
+technique Draw
+{
+	pass
+	{
+		vertex_shader = mainTransform(v_in);
+		pixel_shader = mainImage(v_in);
+	}
+}

--- a/data/shaders/render_output.effect
+++ b/data/shaders/render_output.effect
@@ -22,9 +22,21 @@ VertData mainTransform(VertData v_in)
 	return v_in;
 }
 
+float srgb_nonlinear_to_linear_channel(float u)
+{
+	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+}
+
+float3 srgb_nonlinear_to_linear(float3 v)
+{
+	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
+}
+
 float4 mainImage(VertData v_in) : TARGET
 {
-	return output_image.Sample(textureSampler, v_in.uv);
+	float4 px = output_image.Sample(textureSampler, v_in.uv);
+	px.xyz = srgb_nonlinear_to_linear(px.xyz);
+	return px;
 }
 
 technique Draw

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -406,32 +406,52 @@ static void composite_blur_update(void *data, obs_data_t *settings)
 	}
 }
 
+//static void get_input_source(composite_blur_filter_data_t *filter)
+//{
+//	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+//
+//	const enum gs_color_space preferred_spaces[] = {
+//		GS_CS_SRGB,
+//		GS_CS_SRGB_16F,
+//		GS_CS_709_EXTENDED,
+//	};
+//
+//	const enum gs_color_space source_space = obs_source_get_color_space(
+//		obs_filter_get_target(filter->context),
+//		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+//
+//	const enum gs_color_format format = gs_get_format_from_space(source_space);
+//
+//	filter->input_texrender =
+//		create_or_reset_texrender(filter->input_texrender);
+//	if (obs_source_process_filter_begin_with_color_space(
+//		    filter->context, format, source_space,
+//					    OBS_ALLOW_DIRECT_RENDERING) &&
+//	    gs_texrender_begin(filter->input_texrender, filter->width,
+//			       filter->height)) {
+//
+//		set_blending_parameters();
+//		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+//		gs_ortho(0.0f, (float)filter->width, 0.0f,
+//			 (float)filter->height, -100.0f, 100.0f);
+//		obs_source_process_filter_end(filter->context, pass_through,
+//					      filter->width, filter->height);
+//		gs_texrender_end(filter->input_texrender);
+//		gs_blend_state_pop();
+//	}
+//}
 static void get_input_source(composite_blur_filter_data_t *filter)
 {
 	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 
-	const enum gs_color_space preferred_spaces[] = {
-		GS_CS_SRGB,
-		GS_CS_SRGB_16F,
-		GS_CS_709_EXTENDED,
-	};
-
-	const enum gs_color_space source_space = obs_source_get_color_space(
-		obs_filter_get_target(filter->context),
-		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-
-	const enum gs_color_format format = gs_get_format_from_space(source_space);
-
 	filter->input_texrender =
 		create_or_reset_texrender(filter->input_texrender);
-	if (obs_source_process_filter_begin_with_color_space(
-		    filter->context, format, source_space,
+	if (obs_source_process_filter_begin(filter->context, GS_RGBA,
 					    OBS_ALLOW_DIRECT_RENDERING) &&
 	    gs_texrender_begin(filter->input_texrender, filter->width,
 			       filter->height)) {
 
 		set_blending_parameters();
-		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		gs_ortho(0.0f, (float)filter->width, 0.0f,
 			 (float)filter->height, -100.0f, 100.0f);
 		obs_source_process_filter_end(filter->context, pass_through,
@@ -466,16 +486,13 @@ static void draw_output_to_source(composite_blur_filter_data_t *filter)
 	gs_texture_t *texture =
 		gs_texrender_get_texture(filter->output_texrender);
 	gs_effect_t *pass_through = filter->output_effect;
-	//gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
 	if (filter->param_output_image) {
 		gs_effect_set_texture(filter->param_output_image, texture);
 	}
 	
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-
-	//gs_ortho(0.0f, (float)filter->width, 0.0f, (float)filter->height,
-	//	 -100.0f, 100.0f);
 
 	obs_source_process_filter_end(filter->context, pass_through,
 				      filter->width, filter->height);

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -429,8 +429,31 @@ static void draw_output_to_source(composite_blur_filter_data_t *filter)
 	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 	gs_eparam_t *param = gs_effect_get_param_by_name(pass_through, "image");
 	gs_effect_set_texture(param, texture);
-	while (gs_effect_loop(pass_through, "Draw")) {
-		gs_draw_sprite(texture, 0, filter->width, filter->height);
+	//while (gs_effect_loop(effect, "Draw")) {
+	//	gs_draw_sprite(texture, 0, filter->width, filter->height);
+	//}
+	const enum gs_color_space preferred_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_target(filter->context),
+		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+
+	const enum gs_color_format format =
+		gs_get_format_from_space(source_space);
+	if (obs_source_process_filter_begin_with_color_space(
+		    filter->context, format, source_space,
+		    OBS_ALLOW_DIRECT_RENDERING)) {
+
+		set_blending_parameters();
+		gs_ortho(0.0f, (float)filter->width, 0.0f,
+			 (float)filter->height, -100.0f, 100.0f);
+		obs_source_process_filter_end(filter->context, pass_through,
+					      filter->width, filter->height);
+		gs_blend_state_pop();
 	}
 }
 

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -406,52 +406,32 @@ static void composite_blur_update(void *data, obs_data_t *settings)
 	}
 }
 
-//static void get_input_source(composite_blur_filter_data_t *filter)
-//{
-//	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-//
-//	const enum gs_color_space preferred_spaces[] = {
-//		GS_CS_SRGB,
-//		GS_CS_SRGB_16F,
-//		GS_CS_709_EXTENDED,
-//	};
-//
-//	const enum gs_color_space source_space = obs_source_get_color_space(
-//		obs_filter_get_target(filter->context),
-//		OBS_COUNTOF(preferred_spaces), preferred_spaces);
-//
-//	const enum gs_color_format format = gs_get_format_from_space(source_space);
-//
-//	filter->input_texrender =
-//		create_or_reset_texrender(filter->input_texrender);
-//	if (obs_source_process_filter_begin_with_color_space(
-//		    filter->context, format, source_space,
-//					    OBS_ALLOW_DIRECT_RENDERING) &&
-//	    gs_texrender_begin(filter->input_texrender, filter->width,
-//			       filter->height)) {
-//
-//		set_blending_parameters();
-//		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
-//		gs_ortho(0.0f, (float)filter->width, 0.0f,
-//			 (float)filter->height, -100.0f, 100.0f);
-//		obs_source_process_filter_end(filter->context, pass_through,
-//					      filter->width, filter->height);
-//		gs_texrender_end(filter->input_texrender);
-//		gs_blend_state_pop();
-//	}
-//}
 static void get_input_source(composite_blur_filter_data_t *filter)
 {
 	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 
+	const enum gs_color_space preferred_spaces[] = {
+		GS_CS_SRGB,
+		GS_CS_SRGB_16F,
+		GS_CS_709_EXTENDED,
+	};
+
+	const enum gs_color_space source_space = obs_source_get_color_space(
+		obs_filter_get_target(filter->context),
+		OBS_COUNTOF(preferred_spaces), preferred_spaces);
+
+	const enum gs_color_format format = gs_get_format_from_space(source_space);
+
 	filter->input_texrender =
 		create_or_reset_texrender(filter->input_texrender);
-	if (obs_source_process_filter_begin(filter->context, GS_RGBA,
+	if (obs_source_process_filter_begin_with_color_space(
+		    filter->context, format, source_space,
 					    OBS_ALLOW_DIRECT_RENDERING) &&
 	    gs_texrender_begin(filter->input_texrender, filter->width,
 			       filter->height)) {
 
 		set_blending_parameters();
+		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		gs_ortho(0.0f, (float)filter->width, 0.0f,
 			 (float)filter->height, -100.0f, 100.0f);
 		obs_source_process_filter_end(filter->context, pass_through,
@@ -460,6 +440,26 @@ static void get_input_source(composite_blur_filter_data_t *filter)
 		gs_blend_state_pop();
 	}
 }
+//static void get_input_source(composite_blur_filter_data_t *filter)
+//{
+//	gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+//
+//	filter->input_texrender =
+//		create_or_reset_texrender(filter->input_texrender);
+//	if (obs_source_process_filter_begin(filter->context, GS_RGBA,
+//					    OBS_ALLOW_DIRECT_RENDERING) &&
+//	    gs_texrender_begin(filter->input_texrender, filter->width,
+//			       filter->height)) {
+//
+//		set_blending_parameters();
+//		gs_ortho(0.0f, (float)filter->width, 0.0f,
+//			 (float)filter->height, -100.0f, 100.0f);
+//		obs_source_process_filter_end(filter->context, pass_through,
+//					      filter->width, filter->height);
+//		gs_texrender_end(filter->input_texrender);
+//		gs_blend_state_pop();
+//	}
+//}
 
 
 static void draw_output_to_source(composite_blur_filter_data_t *filter)
@@ -522,16 +522,16 @@ static void composite_blur_video_render(void *data, gs_effect_t *effect)
 		get_input_source(filter);
 
 		// 2. Apply effect to texture, and render texture to video
-		//filter->video_render(filter);
+		filter->video_render(filter);
 
 		//if (filter->mask_type != EFFECT_MASK_TYPE_NONE) {
 		//	// Swap output and render
 		//	apply_effect_mask(filter);
 		//}
 
-		gs_texrender_t *tmp = filter->output_texrender;
-		filter->output_texrender = filter->input_texrender;
-		filter->input_texrender = tmp;
+		//gs_texrender_t *tmp = filter->output_texrender;
+		//filter->output_texrender = filter->input_texrender;
+		//filter->input_texrender = tmp;
 
 
 		// 3. Draw result (filter->output_texrender) to source

--- a/src/obs-composite-blur-filter.c
+++ b/src/obs-composite-blur-filter.c
@@ -8,7 +8,7 @@
 struct obs_source_info obs_composite_blur = {
 	.id = "obs_composite_blur",
 	.type = OBS_SOURCE_TYPE_FILTER,
-	.output_flags = OBS_SOURCE_VIDEO,
+	.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 	.get_name = composite_blur_name,
 	.create = composite_blur_create,
 	.destroy = composite_blur_destroy,
@@ -426,11 +426,12 @@ static void get_input_source(composite_blur_filter_data_t *filter)
 		create_or_reset_texrender(filter->input_texrender);
 	if (obs_source_process_filter_begin_with_color_space(
 		    filter->context, format, source_space,
-					    OBS_NO_DIRECT_RENDERING) &&
+					    OBS_ALLOW_DIRECT_RENDERING) &&
 	    gs_texrender_begin(filter->input_texrender, filter->width,
 			       filter->height)) {
 
 		set_blending_parameters();
+		//gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 		gs_ortho(0.0f, (float)filter->width, 0.0f,
 			 (float)filter->height, -100.0f, 100.0f);
 		obs_source_process_filter_end(filter->context, pass_through,
@@ -439,6 +440,7 @@ static void get_input_source(composite_blur_filter_data_t *filter)
 		gs_blend_state_pop();
 	}
 }
+
 
 static void draw_output_to_source(composite_blur_filter_data_t *filter)
 {
@@ -457,13 +459,14 @@ static void draw_output_to_source(composite_blur_filter_data_t *filter)
 
 	if (!obs_source_process_filter_begin_with_color_space(
 		    filter->context, format, source_space,
-		    OBS_NO_DIRECT_RENDERING)) {
+		    OBS_ALLOW_DIRECT_RENDERING)) {
 		return;
 	}
 
 	gs_texture_t *texture =
 		gs_texrender_get_texture(filter->output_texrender);
 	gs_effect_t *pass_through = filter->output_effect;
+	//gs_effect_t *pass_through = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 	if (filter->param_output_image) {
 		gs_effect_set_texture(filter->param_output_image, texture);
 	}
@@ -471,8 +474,8 @@ static void draw_output_to_source(composite_blur_filter_data_t *filter)
 	gs_blend_state_push();
 	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
 
-	gs_ortho(0.0f, (float)filter->width, 0.0f, (float)filter->height,
-		 -100.0f, 100.0f);
+	//gs_ortho(0.0f, (float)filter->width, 0.0f, (float)filter->height,
+	//	 -100.0f, 100.0f);
 
 	obs_source_process_filter_end(filter->context, pass_through,
 				      filter->width, filter->height);

--- a/src/obs-composite-blur-filter.h
+++ b/src/obs-composite-blur-filter.h
@@ -91,6 +91,7 @@ struct composite_blur_filter_data {
 	gs_effect_t *composite_effect;
 	gs_effect_t *mix_effect;
 	gs_effect_t *effect_mask_effect;
+	gs_effect_t *output_effect;
 
 	// Render pipeline
 	bool input_rendered;
@@ -210,6 +211,9 @@ struct composite_blur_filter_data {
 	float mask_rect_inv;
 	gs_image_file_t *mask_image;
 
+	// Output Effect Parameters
+	gs_eparam_t *param_output_image;
+
 	uint32_t width;
 	uint32_t height;
 
@@ -234,6 +238,7 @@ static obs_properties_t *composite_blur_properties(void *data);
 static void composite_blur_reload_effect(composite_blur_filter_data_t *filter);
 static void load_composite_effect(composite_blur_filter_data_t *filter);
 static void load_mix_effect(composite_blur_filter_data_t *filter);
+static void load_output_effect(composite_blur_filter_data_t *filter);
 extern gs_texture_t *blend_composite(gs_texture_t *texture,
 				     composite_blur_filter_data_t *data);
 


### PR DESCRIPTION
This adds `srgb_nonlinear_to_linear` in the `render_output.effect` effect so colors stay consistent.

I'm not 100% sure it will solve all the color consistency problems. More tests are required to make sure all is good (especially trying sources with other color scheme than sRGB).

Also, alpha channel is still causing troubles. See attached video

Note that this PR is partially based on the work made in branch `bugfix/color-space`

https://github.com/FiniteSingularity/obs-composite-blur/assets/621695/14a25908-9e5b-4d45-9f2b-75854a32dfba